### PR TITLE
Fixing issue where requests include overlapping bytes

### DIFF
--- a/firmware/HttpDownload.cpp
+++ b/firmware/HttpDownload.cpp
@@ -129,7 +129,7 @@ void HttpDownload::sendHeaders(HttpDownloadRequest &request, HttpDownloadHeader 
   itoa(byteRangeStart, itoaBuffer, 10);
   strcat(rangeValue, itoaBuffer);
   strcat(rangeValue, "-");
-  itoa(byteRangeStart + mBytesPerChunk, itoaBuffer, 10);
+  itoa(byteRangeStart + mBytesPerChunk - 1, itoaBuffer, 10);
   strcat(rangeValue, itoaBuffer);
   sendHeader("Range", rangeValue);
   if(request.hostname!=NULL) {


### PR DESCRIPTION
This has been a very useful example, thanks. We did find a bug where an overlapping byte is requested in each chunk -- so requesting both 0-1000 and then 1000-2000 means that the 1000th byte is included in both requests. This caused some interesting results when downloading images. Now it will request, for example, 0-999, 1000-1999, 2000 if downloading in 1000 byte chunks.
